### PR TITLE
Changing requires to install_requires, as that's the setuptools argument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if __name__ == '__main__':
             'scikit-learn>=0.14.1',
             'progressbar',
             'biopython',
-	        'datacache',
+            'datacache',
         ],
         long_description=readme,
         packages=['epitopes'],


### PR DESCRIPTION
Also switching scitkit.learn to its pypi name (scikit_learn), and removing parentheses that aren't proper install_requires format. 
